### PR TITLE
Fix upgrade for functional components, upgrade Tabs recursively in order to fix ripple effect

### DIFF
--- a/docs/pages/components/menu.md
+++ b/docs/pages/components/menu.md
@@ -32,7 +32,7 @@ title: Menu
 {/* Top left */}
 <div style={{position: 'relative'}}>
     <IconButton name="more_vert" id="demo-menu-top-left" />
-    <Menu target="demo-menu-top-left" valign="top">
+    <Menu target="demo-menu-top-left" valign="top" ripple>
         <MenuItem>Some Action</MenuItem>
         <MenuItem>Another Action</MenuItem>
         <MenuItem disabled>Disabled Action</MenuItem>
@@ -43,7 +43,7 @@ title: Menu
 {/* Top right */}
 <div style={{position: 'relative'}}>
     <IconButton name="more_vert" id="demo-menu-top-right" />
-    <Menu target="demo-menu-top-right" valign="top" align="right">
+    <Menu target="demo-menu-top-right" valign="top" align="right" ripple>
         <MenuItem>Some Action</MenuItem>
         <MenuItem>Another Action</MenuItem>
         <MenuItem disabled>Disabled Action</MenuItem>

--- a/docs/wrappers/md.js
+++ b/docs/wrappers/md.js
@@ -38,8 +38,6 @@ class MarkdownWrapper extends React.Component {
         const demoJs = document.querySelectorAll('.demo-js');
         Array.from(demoJs).forEach(code => eval(code.innerHTML));
 
-        window.componentHandler.upgradeElements(findDOMNode(this));
-
         const dialogs = document.querySelectorAll('dialog');
         [].slice.call(dialogs).forEach(dialog => window.dialogPolyfill.registerDialog(dialog));
     }

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -46,4 +46,4 @@ class Checkbox extends React.Component {
 
 Checkbox.propTypes = propTypes;
 
-export default mdlUpgrade(Checkbox);
+export default mdlUpgrade(Checkbox, true);

--- a/src/IconToggle.js
+++ b/src/IconToggle.js
@@ -47,4 +47,4 @@ class IconToggle extends React.Component {
 
 IconToggle.propTypes = propTypes;
 
-export default mdlUpgrade(IconToggle);
+export default mdlUpgrade(IconToggle, true);

--- a/src/Layout/HeaderTabs.js
+++ b/src/Layout/HeaderTabs.js
@@ -7,7 +7,8 @@ const HeaderTabs = props => {
     const { className, ripple, children, ...otherProps } = props;
 
     const classes = classNames({
-        'mdl-js-ripple-effect': ripple
+        'mdl-js-ripple-effect': ripple,
+        'mdl-js-ripple-effect--ignore-events': ripple
     }, className);
 
     return (

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -32,4 +32,4 @@ class Layout extends React.Component {
 
 Layout.propTypes = propTypes;
 
-export default mdlUpgrade(Layout);
+export default mdlUpgrade(Layout, true);

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -38,5 +38,5 @@ class Menu extends React.Component {
 Menu.propTypes = propTypes;
 Menu.defaultProps = defaultProps;
 
-export default mdlUpgrade(Menu);
+export default mdlUpgrade(Menu, true);
 export const MenuItem = basicClassCreator('MenuItem', 'mdl-menu__item', 'li');

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -52,4 +52,4 @@ class Radio extends React.Component {
 
 Radio.propTypes = propTypes;
 
-export default mdlUpgrade(Radio);
+export default mdlUpgrade(Radio, true);

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -45,4 +45,4 @@ class Switch extends React.Component {
 
 Switch.propTypes = propTypes;
 
-export default mdlUpgrade(Switch);
+export default mdlUpgrade(Switch, true);

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -40,4 +40,4 @@ const Tabs = props => {
 
 Tabs.propTypes = propTypes;
 
-export default mdlUpgrade(Tabs);
+export default mdlUpgrade(Tabs, true);

--- a/src/utils/MDLComponent.js
+++ b/src/utils/MDLComponent.js
@@ -1,9 +1,13 @@
-import { Children, Component } from 'react';
+import { Children, Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 
 export default class MDLComponent extends Component {
     componentDidMount() {
-        window.componentHandler.upgradeElement(findDOMNode(this));
+        if (this.props.recursive) {
+            window.componentHandler.upgradeElements(findDOMNode(this));
+        } else {
+            window.componentHandler.upgradeElement(findDOMNode(this));
+        }
     }
 
     componentWillUnmount() {
@@ -13,4 +17,9 @@ export default class MDLComponent extends Component {
     render() {
         return Children.only(this.props.children);
     }
+
 }
+
+MDLComponent.propTypes = {
+    recursive: PropTypes.bool
+};

--- a/src/utils/mdlUpgrade.js
+++ b/src/utils/mdlUpgrade.js
@@ -1,19 +1,25 @@
 import * as React from 'react';
 import MDLComponent from './MDLComponent';
 
-function patchComponentClass(Component) {
-    const render = Component.prototype.render;
+function patchComponentClass(Component, recursive) {
+    const oldRender = Component.prototype.render;
 
-    Component.prototype.render = function rendr() { // eslint-disable-line no-param-reassign
-        const renderBound = render.bind(this);
-        return <MDLComponent>{renderBound()}</MDLComponent>;
+    Component.prototype.render = function render() { // eslint-disable-line no-param-reassign
+        return (
+            <MDLComponent recursive={recursive}>
+                {oldRender.call(this)}
+            </MDLComponent>
+        );
     };
 
     return Component;
 }
 
-function patchSFC(component) {
-    const patchedComponent = props => <MDLComponent>{component(props)}</MDLComponent>;
+function patchSFC(component, recursive) {
+    const patchedComponent = props =>
+        <MDLComponent recursive={recursive}>
+            {component(props)}
+        </MDLComponent>;
 
     Object.defineProperty(patchedComponent, 'name', {
         value: component.name
@@ -22,8 +28,8 @@ function patchSFC(component) {
     return patchedComponent;
 }
 
-export default Component => (
+export default (Component, recursive = false) => (
     (Component.prototype && Component.prototype.isReactComponent) ?
-        patchComponentClass(Component) :
-        patchSFC(Component)
+        patchComponentClass(Component, recursive) :
+        patchSFC(Component, recursive)
 );

--- a/src/utils/mdlUpgrade.js
+++ b/src/utils/mdlUpgrade.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import * as React from 'react';
 import MDLComponent from './MDLComponent';
 
-export default Component => {
+function patchComponentClass(Component) {
     const render = Component.prototype.render;
 
     Component.prototype.render = function rendr() { // eslint-disable-line no-param-reassign
@@ -10,4 +10,20 @@ export default Component => {
     };
 
     return Component;
-};
+}
+
+function patchSFC(component) {
+    const patchedComponent = props => <MDLComponent>{component(props)}</MDLComponent>;
+
+    Object.defineProperty(patchedComponent, 'name', {
+        value: component.name
+    });
+
+    return patchedComponent;
+}
+
+export default Component => (
+    (Component.prototype && Component.prototype.isReactComponent) ?
+        patchComponentClass(Component) :
+        patchSFC(Component)
+);


### PR DESCRIPTION
Hi all!

This PR fixes component upgrades to correctly handle stateless functional components.

In addition `Tabs` require a recursive update via `componentHandler.upgradeElements` in order for ripple to work. To this end, this PR introduces a recusive mode of operation in `MDLComponent`. Together, these two changes fix issues #394 and #415.

Both issues do not show up on the documentation pages. This is because the markdown bootstraps calls `upgradeElements` on the whole page. This PR removes this call, bringing documentation into line with the actual component behavior.

Cheers
-Christian
