### PR TITLE
Allow extra props on Badge component

### DIFF
--- a/src/Badge/index.js
+++ b/src/Badge/index.js
@@ -16,7 +16,7 @@ const propTypes = {
 };
 
 const Badge = props => {
-    const { children, className, text, overlap, noBackground } = props;
+    const { children, className, text, overlap, noBackground, ...rest } = props;
 
     // No badge if no children
     // TODO: In React 15, we can return null instead
@@ -30,6 +30,7 @@ const Badge = props => {
     if (text === null || typeof text === 'undefined') return element;
 
     return React.cloneElement(element, {
+        ...rest,
         className: classNames(className, element.props.className, 'mdl-badge', {
             'mdl-badge--overlap': !!overlap,
             'mdl-badge--no-background': !!noBackground


### PR DESCRIPTION
Adds the ability to pass extra props such as `onClick` handler on `Badge` component. @tleunen please let me know if this makes sense.