### PR TITLE
Restore menu DOM after downgrade in order to allow react to cleanly unmount the component.

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
-import mdlUpgrade from './utils/mdlUpgrade';
 import basicClassCreator from './utils/basicClassCreator';
 
 const propTypes = {
@@ -18,6 +18,23 @@ const defaultProps = {
 
 // eslint-disable-next-line react/prefer-stateless-function
 class Menu extends React.Component {
+    componentDidMount() {
+        window.componentHandler.upgradeElements(findDOMNode(this));
+    }
+
+    componentWillUnmount() {
+        const elt = findDOMNode(this);
+
+        window.componentHandler.downgradeElements(elt);
+
+        const parent = elt.parentElement;
+        const grandparent = parent && parent.parentElement;
+
+        if (parent && grandparent && parent.classList.contains('mdl-menu__container')) {
+            grandparent.replaceChild(elt, parent);
+        }
+    }
+
     render() {
         const { align, children, className, ripple,
             target, valign, ...otherProps } = this.props;
@@ -38,5 +55,5 @@ class Menu extends React.Component {
 Menu.propTypes = propTypes;
 Menu.defaultProps = defaultProps;
 
-export default mdlUpgrade(Menu, true);
+export default Menu;
 export const MenuItem = basicClassCreator('MenuItem', 'mdl-menu__item', 'li');

--- a/src/__tests__/Menu-test.js
+++ b/src/__tests__/Menu-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import expect from 'expect';
 import React from 'react';
-import { render } from './render';
+import { render, renderDOM } from './render';
 import Menu from '../Menu';
 
 describe('Menu', () => {
@@ -34,5 +34,36 @@ describe('Menu', () => {
 
         expect(output.props.className)
             .toInclude('mdl-js-ripple-effect');
+    });
+
+    it('should unmount cleanly', () => {
+        let removeMenuCallback;
+
+        class Testbed extends React.Component {
+            constructor(props, ctx) {
+                super(props, ctx);
+
+                this.state = {
+                    showMenu: true
+                };
+
+                removeMenuCallback = () => this.setState({ showMenu: false });
+            }
+
+            render() {
+                return (
+                    <div>
+                        {this.state.showMenu ? <Menu className="test-menu" /> : <span />}
+                    </div>
+                );
+            }
+        }
+
+        const node = renderDOM(<Testbed />);
+
+        expect(node.querySelectorAll('.test-menu').length).toBe(1);
+        expect(removeMenuCallback).toBeTruthy();
+        expect(removeMenuCallback).toNotThrow();
+        expect(node.querySelectorAll('.test-menu').length).toBe(0);
     });
 });


### PR DESCRIPTION
This PR fixes #426 