### PR TITLE
Fix IE10 dataTable select not able to use HTML5 data attributes

### DIFF
--- a/src/DataTable/Selectable.js
+++ b/src/DataTable/Selectable.js
@@ -82,7 +82,7 @@ export default Component => {
 
         handleChangeRowCheckbox(e) {
             const { rows, data } = this.props;
-            const rowId = JSON.parse(e.target.dataset.reactmdl).id;
+            const rowId = JSON.parse(e.target.dataset ? e.target.dataset.reactmdl: e.target.getAttribute('data-reactmdl')).id;
             const rowChecked = e.target.checked;
             const selectedRows = this.state.selectedRows;
 


### PR DESCRIPTION
Using react-mdl dataTable on IE10 noticed the select was failing as IE10 does not support data attributes. This ensures that it uses the 'old' way of getting attributes.