### PR TITLE
Detecting Dialog backdrop clicks.

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 const propTypes = {
     className: PropTypes.string,
     onCancel: PropTypes.func,
+    onBackdropClick: PropTypes.func,
     open: PropTypes.bool
 };
 
@@ -14,6 +15,8 @@ const defaultProps = {
 
 class Dialog extends React.Component {
     componentDidMount() {
+        this.backdropClickCallback = this.onDialogClick.bind(this);
+        this.dialogRef.addEventListener('click', this.backdropClickCallback);
         this.dialogRef.addEventListener('cancel', this.props.onCancel);
         if (this.props.open) {
             findDOMNode(this).showModal();
@@ -41,13 +44,31 @@ class Dialog extends React.Component {
 
     componentWillUnmount() {
         this.dialogRef.removeEventListener('cancel', this.props.onCancel);
+        this.dialogRef.removeEventListener('click', this.backdropClickCallback);
+    }
+
+    onDialogClick(event) {
+        // http://stackoverflow.com/a/26984690
+        if (this.props.onBackdropClick && event.target === this.dialogRef) {
+            const rect = this.dialogRef.getBoundingClientRect();
+            const insideDialog = (
+                rect.top <= event.clientY &&
+                event.clientY <= rect.top + rect.height &&
+                rect.left <= event.clientX &&
+                event.clientX <= rect.left + rect.width
+            );
+
+            if (!insideDialog) {
+                this.props.onBackdropClick();
+            }
+        }
     }
 
     render() {
         // We cannot set the `open` prop on the Dialog if we manage its state manually with `showModal`,
         // this the disabled eslint rule
         // eslint-disable-next-line no-unused-vars
-        const { className, open, onCancel, children, ...otherProps } = this.props;
+        const { className, open, onCancel, children, onBackdropClick, ...otherProps } = this.props;
 
         const classes = classNames('mdl-dialog', className);
 


### PR DESCRIPTION
This PR allows the user to pass a function to be called when the Dialog backdrop is clicked by checking if the user click is inside the bounds of the modal dialog. It accounts for the possibility of fields that don't report clientY / clientX correctly (like selectfield).

This was tested with Google Chrome only.