### PR TITLE
[DataTable] Selected rows as props

### DIFF
--- a/src/DataTable/Selectable.js
+++ b/src/DataTable/Selectable.js
@@ -37,7 +37,7 @@ export default Component => {
             if (props.selectable) {
                 this.state = {
                     headerSelected: false,
-                    selectedRows: []
+                    selectedRows: props.selectedRows || []
                 };
             }
         }
@@ -47,9 +47,10 @@ export default Component => {
                 const { rows, data, rowKeyColumn } = nextProps;
                 const rrows = rows || data;
 
-                if (!isEqual(this.props.rows || this.props.data, rrows)) {
+                if (!isEqual(this.props.rows || this.props.data, rrows) ||
+                    !isEqual(this.props.selectedRows, nextProps.selectedRows)) {
                     // keep only existing rows
-                    const selectedRows = this.state.selectedRows
+                    const selectedRows = (nextProps.selectedRows || this.state.selectedRows)
                         .filter(k => rrows
                             .map((row, i) => row[rowKeyColumn] || row.key || i)
                             .indexOf(k) > -1
@@ -60,7 +61,7 @@ export default Component => {
                         selectedRows
                     });
 
-                    nextProps.onSelectionChanged(selectedRows);
+                    !nextProps.selectedRows && nextProps.onSelectionChanged(selectedRows);
                 }
             }
         }

--- a/src/DataTable/__tests__/Selectable-test.js
+++ b/src/DataTable/__tests__/Selectable-test.js
@@ -229,5 +229,17 @@ describe('Selectable Table', () => {
             wrapper.setProps({ rows: nRows });
             expect(headerCheckbox).to.be.checked();
         });
+
+        it('should accept selected rows as prop', () => {
+            const wrapper = mount(getSortableTable({
+                rows: oldRows,
+                rowKeyColumn: 'id',
+                selectedRows: [1001, 1002]
+            }));
+
+            expect(getElementByRowId(wrapper, 1000)).to.not.be.checked();
+            expect(getElementByRowId(wrapper, 1001)).to.be.checked();
+            expect(getElementByRowId(wrapper, 1002)).to.be.checked();
+        })
     });
 });


### PR DESCRIPTION
This PR allows you to pass an array of selected rows as a prop (`selectedRows`) as mentioned in #404.

```js
const rows = [
  { id: '1001', name: 'Row 1001' }, 
  { id: '1002', name: 'Row 1002' }
]

const selectedRows = ['1001']

<DataTable selectable rowKeyColumn="id" rows={rows} selectedRows={selectedRows}>
  <TableHeader name="id">Id</TableHeader>
  <TableHeader name="name">Name</TableHeader>
</DataTable>
```