### PR TITLE
use `PropTypes` instead of `React.PropTypes`

### DIFF
--- a/src/Badge/index.js
+++ b/src/Badge/index.js
@@ -9,8 +9,8 @@ const propTypes = {
     ]),
     className: PropTypes.string,
     text: PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number
+        PropTypes.string,
+        PropTypes.number
     ]),
     overlap: PropTypes.bool,
     noBackground: PropTypes.bool


### PR DESCRIPTION
Please update and republish.