### PR TITLE
Fix React import

### DIFF
--- a/src/utils/mdlUpgrade.js
+++ b/src/utils/mdlUpgrade.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import MDLComponent from './MDLComponent';
 
 function patchComponentClass(Component, recursive) {


### PR DESCRIPTION
Importing * as React seems to trigger the React.PropTypes warning.

I don't see a reason for doing it either