### PR TITLE
fixes #459

### DIFF
--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -6,13 +6,10 @@ const RadioGroup = (props) => {
     const { name, value, children, container,
         childContainer, onChange, ...otherProps } = props;
 
-    const hasOnChange = typeof onChange === 'function';
-    const checked = hasOnChange ? 'checked' : 'defaultChecked';
-
     return React.createElement(container, otherProps,
         React.Children.map(children, child => {
             const clonedChild = React.cloneElement(child, {
-                [checked]: child.props.value === value,
+                checked: child.props.value === value,
                 name,
                 onChange,
                 ...otherProps

--- a/src/__tests__/RadioGroup-test.js
+++ b/src/__tests__/RadioGroup-test.js
@@ -62,7 +62,7 @@ describe('RadioGroup', () => {
 
         for (let i = 0; i < output.props.children.length; i++) {
             const radio = output.props.children[i];
-            expect(radio.props.defaultChecked).toBe(value === radio.props.value);
+            expect(radio.props.checked).toBe(value === radio.props.value);
         }
     });
 


### PR DESCRIPTION
# fixes #459 

Apparently, there was an attribute for `radioGroup`s called `defaultChecked`, when it had an `onChange` event related. Using this attribute, the radioGroup's internal state changes, but it doesn't reflect this change in the view (the default selected radio option still selected).

In this PR, I've removed the `defaultChecked` from `RadioGroup`, keeping only `checked`, which is really used in Radio Component.